### PR TITLE
Add enhanced admin prayer management features

### DIFF
--- a/Client/src/components/admin/AdminPager.tsx
+++ b/Client/src/components/admin/AdminPager.tsx
@@ -21,9 +21,9 @@ export default function AdminPager({ total, page, pageSize }: Readonly<{
     <div className="flex items-center justify-between text-sm">
       <div>Total: {total}</div>
       <div className="flex gap-2">
-        <button onClick={prev} className="rounded-lg border px-3 py-1 hover:bg-[var(--theme-card-hover)]" disabled={page <= 1}>Prev</button>
+        <button onClick={prev} className="rounded-lg border px-3 py-1 hover:bg-[var(--theme-button-hover)]" disabled={page <= 1}>Prev</button>
         <div>Page {page} / {totalPages}</div>
-        <button onClick={next} className="rounded-lg border px-3 py-1 hover:bg-[var(--theme-card-hover)]" disabled={page >= totalPages}>Next</button>
+        <button onClick={next} className="rounded-lg border px-3 py-1 hover:bg-[var(--theme-button-hover)]" disabled={page >= totalPages}>Next</button>
       </div>
     </div>
   );

--- a/Client/src/components/admin/AdminPrayerSummaryCard.tsx
+++ b/Client/src/components/admin/AdminPrayerSummaryCard.tsx
@@ -7,6 +7,11 @@ type Props = {
   className?: string;
 };
 
+function formatStatus(s: string): string {
+  const coerced = s === 'active' ? 'prayer' : s;
+  return coerced.charAt(0).toUpperCase() + coerced.slice(1);
+}
+
 export default function AdminPrayerSummaryCard({
                                                  prayerId,
                                                  className,
@@ -25,6 +30,7 @@ export default function AdminPrayerSummaryCard({
 
   const category = row?.category ?? (prayer?.category as string) ?? 'prayer';
   const status = row?.status ?? (prayer?.status as string) ?? 'active';
+  const statusDisplay = formatStatus(status);
   const updatedAt = row?.updatedAt ? new Date(row.updatedAt) : undefined;
   const lastCommentAt = row?.lastCommentAt ? new Date(row.lastCommentAt) : undefined;
   const commentCount = typeof row?.commentCount === 'number' ? row.commentCount : 0;
@@ -64,7 +70,7 @@ export default function AdminPrayerSummaryCard({
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3 mb-4">
         <InfoRow label="Category" value={category} />
-        <InfoRow label="Status" value={status} />
+        <InfoRow label="Status" value={statusDisplay} />
         <InfoRow label="Comments" value={commentCount} />
         <InfoRow label="Last Comment" value={lastCommentAt ? lastCommentAt.toLocaleString() : '—'} />
         <InfoRow label="Updated" value={updatedAt ? updatedAt.toLocaleString() : '—'} />

--- a/Client/src/components/admin/AdminPrayerSummaryCard.tsx
+++ b/Client/src/components/admin/AdminPrayerSummaryCard.tsx
@@ -12,6 +12,19 @@ function formatStatus(s: string): string {
   return coerced.charAt(0).toUpperCase() + coerced.slice(1);
 }
 
+const InfoRow = React.memo(function InfoRow({
+                                              label,
+                                              value,
+                                            }: Readonly<{ label: string; value?: React.ReactNode }>): React.ReactElement | null {
+  if (!value && value !== 0) return null;
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+      <span className="text-xs sm:text-sm opacity-80">{label}:</span>
+      <span className="text-sm sm:text-base">{value}</span>
+    </div>
+  );
+});
+
 export default function AdminPrayerSummaryCard({
                                                  prayerId,
                                                  className,
@@ -36,19 +49,6 @@ export default function AdminPrayerSummaryCard({
   const commentCount = typeof row?.commentCount === 'number' ? row.commentCount : 0;
 
   const content = prayer?.content ?? '';
-
-  function InfoRow({
-                     label,
-                     value,
-                   }: Readonly<{ label: string; value?: React.ReactNode }>): React.ReactElement | null {
-    if (!value && value !== 0) return null;
-    return (
-      <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
-        <span className="text-xs sm:text-sm opacity-80">{label}:</span>
-        <span className="text-sm sm:text-base">{value}</span>
-      </div>
-    );
-  }
 
   return (
     <div

--- a/Client/src/components/admin/AdminPrayersTable.tsx
+++ b/Client/src/components/admin/AdminPrayersTable.tsx
@@ -40,7 +40,7 @@ export default function AdminPrayersTable(
       </thead>
       <tbody>
       {rows.map((r) => (
-        <tr key={r.id} className="border-t border-[var(--theme-border)] hover:bg-[var(--theme-card-hover)]">
+        <tr key={r.id} className="border-t border-[var(--theme-border)] hover:bg-[var(--theme-card-hover-alt)]">
           <td className="p-3">
             <Link
               to={`/admin/prayers/${r.id}`}

--- a/Client/src/helpers/api/adminApi.ts
+++ b/Client/src/helpers/api/adminApi.ts
@@ -58,18 +58,15 @@ export async function patchPrayerStatus(
   );
 }
 
-// Client/src/helpers/api/adminApi.ts
-export async function deleteAdminPrayer(
-  prayerId: number,
-  recaptchaToken?: string
-): Promise<Response> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (recaptchaToken) headers['x-recaptcha-token'] = recaptchaToken;
-
-  return fetch(`/api/admin/prayers/${prayerId}`, {
-    method: 'DELETE',
-    credentials: 'include',
-    headers,
-  });
+/** DELETE /admin/prayers/:id — keep Response shape; attach recaptcha header when available */
+export async function deleteAdminPrayer(prayerId: number): Promise<Response> {
+  return apiWithRecaptcha(
+    `/api/admin/prayers/${prayerId}`,
+    'admin_prayer_delete',
+    {
+      method: 'DELETE',
+    }
+  );
 }
+
 

--- a/Client/src/helpers/api/adminApi.ts
+++ b/Client/src/helpers/api/adminApi.ts
@@ -57,3 +57,19 @@ export async function patchPrayerStatus(
     }
   );
 }
+
+// Client/src/helpers/api/adminApi.ts
+export async function deleteAdminPrayer(
+  prayerId: number,
+  recaptchaToken?: string
+): Promise<Response> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (recaptchaToken) headers['x-recaptcha-token'] = recaptchaToken;
+
+  return fetch(`/api/admin/prayers/${prayerId}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers,
+  });
+}
+

--- a/Client/src/index.css
+++ b/Client/src/index.css
@@ -54,6 +54,7 @@
     /* cards & interactive */
     --theme-card: var(--c-b);
     --theme-card-hover: var(--c-c);
+    --theme-card-hover-alt: var(--c-b);
     --theme-card-alt: var(--c-f);
     --theme-hover: var(--c-d);
 
@@ -120,6 +121,7 @@
     /* cards & interactive */
     --theme-card: var(--c-d);
     --theme-card-hover: var(--c-b);
+    --theme-card-hover-alt: var(--c-b);
     --theme-card-alt: var(--c-h); /* darker parchment substitute */
     --theme-hover: var(--c-b);
 

--- a/Client/src/pages/admin/AdminPrayerDetailPage.tsx
+++ b/Client/src/pages/admin/AdminPrayerDetailPage.tsx
@@ -68,7 +68,7 @@ export default function AdminPrayerDetailPage(): React.ReactElement {
 
       if (state && typeof state.deletePrayer === 'function') {
         const res = await state.deletePrayer(prayerId);
-        if (res && res.ok) {
+        if (res?.ok) {
           setShowDeleteConfirm(false);
           onBack();
           return;
@@ -151,7 +151,7 @@ export default function AdminPrayerDetailPage(): React.ReactElement {
             <button
               type="button"
               onClick={onSetStatus}
-              className="rounded-xl bg-[var(--theme-button)] text-[var(--theme-text-white)] px-4 py-2 hover:bg-[var(--theme-button-hover)]"
+              className="rounded-xl bg-[var(--theme-button)] text-[var(--theme-text-white)] px-4 py-2 hover:bg-[var(--theme-button-hover)] hover:text-[var(--theme-textbox)]"
             >
               Update Status
             </button>
@@ -159,7 +159,7 @@ export default function AdminPrayerDetailPage(): React.ReactElement {
             <button
               type="button"
               onClick={onClickDelete}
-              className="rounded-xl bg-[var(--theme-error)] text-[var(--theme-textbox)] px-4 py-2 hover:opacity-90"
+              className="rounded-xl bg-[var(--theme-error)] text-[var(--theme-textbox)] px-4 py-2 hover:bg-[var(--theme-button-error)]"
               aria-label="Delete prayer"
             >
               Delete

--- a/Client/src/pages/admin/AdminPrayerDetailPage.tsx
+++ b/Client/src/pages/admin/AdminPrayerDetailPage.tsx
@@ -120,7 +120,7 @@ export default function AdminPrayerDetailPage(): React.ReactElement {
           type="button"
           onClick={onBack}
           className="rounded-xl bg-[var(--theme-surface)] border border-[var(--theme-border)]
-                     px-3 py-1.5 text-sm hover:bg-[var(--theme-card-hover)]"
+                     px-3 py-1.5 text-sm hover:text-[var(--theme-textbox)] hover:bg-[var(--theme-button-hover)] transition-colors duration-200"
         >
           ← Back to list
         </button>
@@ -151,7 +151,7 @@ export default function AdminPrayerDetailPage(): React.ReactElement {
             <button
               type="button"
               onClick={onSetStatus}
-              className="rounded-xl bg-[var(--theme-button)] text-[var(--theme-text-white)] px-4 py-2 hover:bg-[var(--theme-button-hover)] hover:text-[var(--theme-textbox)]"
+              className="rounded-xl bg-[var(--theme-button)] text-[var(--theme-text-white)] px-4 py-2 hover:bg-[var(--theme-button-hover)] hover:text-[var(--theme-textbox)] transition-colors duration-200"
             >
               Update Status
             </button>
@@ -159,7 +159,7 @@ export default function AdminPrayerDetailPage(): React.ReactElement {
             <button
               type="button"
               onClick={onClickDelete}
-              className="rounded-xl bg-[var(--theme-error)] text-[var(--theme-textbox)] px-4 py-2 hover:bg-[var(--theme-button-error)]"
+              className="rounded-xl bg-[var(--theme-error)] text-[var(--theme-textbox)] px-4 py-2 hover:bg-[var(--theme-button-error)] transition-colors duration-200"
               aria-label="Delete prayer"
             >
               Delete
@@ -198,7 +198,7 @@ export default function AdminPrayerDetailPage(): React.ReactElement {
         <div className="mt-2 flex justify-end">
           <button
             onClick={onPost}
-            className="rounded-xl bg-[var(--theme-button-blue)] text-[var(--theme-text-white)] px-4 py-2 hover:bg-[var(--theme-button-blue-hover)]"
+            className="rounded-xl bg-[var(--theme-button)] text-[var(--theme-text-white)] px-4 py-2 hover:text-[var(--theme-textbox)] hover:bg-[var(--theme-button-hover)] transition-colors duration-200"
           >
             Post
           </button>

--- a/Client/src/stores/useSocketStore.ts
+++ b/Client/src/stores/useSocketStore.ts
@@ -111,7 +111,7 @@ export const useSocketStore = create<SocketState>((set, get) => {
   function onPrayerUpdated(d: PrayerUpdatedPayload) {
     try { get().enqueue({ type: 'upsert', p: d.prayer }); } catch {}
     try { praisesOnSocketUpsert(d.prayer); } catch {}
-    try { myPrayersOnSocketUpsert(d.prayer); } catch {}   // ← ADD
+    try { myPrayersOnSocketUpsert(d.prayer); } catch {}
     // NOTE: no explicit rebuildColumn call needed; upsertPrayer re-sorts by `position`.
   }
 
@@ -125,7 +125,7 @@ export const useSocketStore = create<SocketState>((set, get) => {
       onE<PrayerCreatedPayload>(Events.PrayerCreated, (d) => {
         try { get().enqueue({ type: 'upsert', p: d.prayer }); } catch {}
         try { praisesOnSocketUpsert(d.prayer); } catch {}
-        try { myPrayersOnSocketUpsert(d.prayer); } catch {}   // ← ADD
+        try { myPrayersOnSocketUpsert(d.prayer); } catch {}
       });
 
       onE<PrayerUpdatedPayload>(Events.PrayerUpdated, onPrayerUpdated);
@@ -134,13 +134,16 @@ export const useSocketStore = create<SocketState>((set, get) => {
         try { get().enqueue({ type: 'upsert', p: d.prayer }); } catch {}
         try { get().enqueue({ type: 'move', id: d.prayer.id, to: d.to }); } catch {}
         try { praisesOnSocketUpsert(d.prayer); } catch {}
-        try { myPrayersOnSocketUpsert(d.prayer); } catch {}   // ← ADD
+        try { myPrayersOnSocketUpsert(d.prayer); } catch {}
       });
 
       onE<PrayerDeletedPayload>(Events.PrayerDeleted, (d) => {
-        // keep board logic as-is (no 'remove' Patch variant); mirror praises behavior
+        // ✅ NEW: remove from the board immediately
+        try { useBoardStore.getState().removePrayer(d.id); } catch {}
+
+        // existing behaviors (keep them)
         try { praisesOnSocketRemove(d.id); } catch {}
-        try { myPrayersOnSocketRemove(d.id); } catch {}       // ← ADD
+        try { myPrayersOnSocketRemove(d.id); } catch {}
       });
 
       // When an update is added to a prayer, bump it visually right away.

--- a/Server/src/controllers/admin/admin.controller.ts
+++ b/Server/src/controllers/admin/admin.controller.ts
@@ -48,8 +48,16 @@ export async function addAdminComment(req: Request, res: Response): Promise<void
   if (!content?.trim()) { res.status(400).json({ error: 'Content required.' }); return; }
 
   try {
-    const c = await insertAdminComment(Number(prayerId), adminId, content.trim());
-    res.json({ ok: true, comment: c });
+    const result = await insertAdminComment(Number(prayerId), adminId, content.trim());
+    if (!result.ok) { res.status(500).json({ error: result.error }); return; }
+
+    // match the shape the client (and socket handlers) expect:
+    res.json({
+      ok: true,
+      comment: result.comment,
+      newCount: result.newCount,
+      lastCommentAt: result.lastCommentAt ? new Date(result.lastCommentAt).toISOString() : null,
+    });
   } catch {
     res.status(500).json({ error: 'Could not add comment.' });
   }

--- a/Server/src/controllers/prayer.controller.ts
+++ b/Server/src/controllers/prayer.controller.ts
@@ -1,18 +1,19 @@
 // Server/src/controllers/prayer.controller.ts
 import type { Request, Response } from 'express';
 import type { Order, WhereOptions } from 'sequelize';
-import { Group, PrayerUpdate, User, Attachment, PrayerParticipant } from '../models/index.js';
-import { sequelize } from '../config/sequelize.config.js';
-import { Prayer, type Status } from '../models/prayer.model.js';
-import { emitToGroup } from '../config/socket.config.js';
-import path from 'path';
-import { env } from '../config/env.config.js';
 
-// NEW: typed events + DTO mapper
+import path from 'path';
+
+import { sequelize } from '../config/sequelize.config.js';
+import { env } from '../config/env.config.js';
+import { emitToGroup } from '../config/socket.config.js';
+
+import { Group, PrayerUpdate, User, Attachment, PrayerParticipant } from '../models/index.js';
+import { Prayer, type Status } from '../models/prayer.model.js';
+
 import { Events } from '../types/socket.types.js';
 import { toPrayerDTO } from './dto/prayer.dto.js';
 
-// NEW: Resend helpers (logic-only service)
 import {
   notifyGroupOnCategoryCreate,
   notifyAdminOnCategoryCreate,
@@ -35,7 +36,7 @@ async function findPrayerOr404(
 }
 
 /** ------------------------------------------------------------------------
- * NEW: Keep column positions dense so manual sorting remains meaningful.
+ * Keep column positions dense so manual sorting remains meaningful.
  * Re-pack positions to 0..N-1 and emit per-item updates so clients reconcile.
  * Non-fatal: any failure is swallowed.
  * -----------------------------------------------------------------------*/
@@ -47,21 +48,24 @@ async function normalizePositions(groupId: number, status: Status): Promise<void
       attributes: ['id', 'position', 'groupId', 'status'],
     });
 
-    // Detect negatives/gaps; only rewrite if needed.
     let needs = false;
     for (let i = 0; i < rows.length; i++) {
       const expected = i;
       const actual = Number(rows[i].position ?? 0);
-      if (actual !== expected) { needs = true; break; }
+      if (actual !== expected) {
+        needs = true;
+        break;
+      }
     }
     if (!needs) return;
 
     for (let i = 0; i < rows.length; i++) {
       try {
         await Prayer.update({ position: i }, { where: { id: rows[i].id } });
-      } catch {}
+      } catch {
+        // best-effort
+      }
 
-      // Emit per-item so all clients deterministically reconcile order.
       try {
         const p = await Prayer.findByPk(rows[i].id, {
           include: [{ model: User, as: 'author', attributes: ['id', 'name'] }],
@@ -71,7 +75,9 @@ async function normalizePositions(groupId: number, status: Status): Promise<void
           emitToGroup(p.groupId, 'prayer:updated', payload);
           emitToGroup(p.groupId, Events.PrayerUpdated, payload);
         }
-      } catch {}
+      } catch {
+        // best-effort
+      }
     }
   } catch {
     // non-fatal
@@ -93,17 +99,14 @@ export async function listPrayers(req: Request, res: Response): Promise<void> {
 
   const include = [{ model: User, as: 'author', attributes: ['id', 'name'] }];
 
-  // Build a Sequelize Order without using `any`
   let order: Order;
   if (sort === 'name') {
     order = [[{ model: User, as: 'author' }, 'name', dir]];
   } else if (sort === 'prayer') {
     order = [['title', dir]];
   } else if (sort === 'status') {
-    // status column ordering then position in the column
     order = [['status', 'asc'], ['position', 'asc']];
   } else {
-    // date
     order = [['createdAt', dir]];
   }
 
@@ -112,7 +115,7 @@ export async function listPrayers(req: Request, res: Response): Promise<void> {
     include,
     order,
     limit: pageSize,
-    offset: (page - 1) * pageSize
+    offset: (page - 1) * pageSize,
   });
 
   const rowsWithAuthor = rows as Array<Prayer & { author?: { id: number; name: string } }>;
@@ -130,7 +133,7 @@ export async function listPrayers(req: Request, res: Response): Promise<void> {
 }
 
 /** ------------------------------------------------------------------------
- * NEW: listMyPrayers — only prayers created by the authenticated user
+ * listMyPrayers — only prayers created by the authenticated user
  * Mirrors listPrayers query params & ordering; returns DTOs.
  * -----------------------------------------------------------------------*/
 export async function listMyPrayers(req: Request, res: Response): Promise<void> {
@@ -143,12 +146,11 @@ export async function listMyPrayers(req: Request, res: Response): Promise<void> 
   const dir = (req.query.dir as 'asc' | 'desc') ?? 'desc';
 
   const where: WhereOptions = { authorUserId: req.user!.userId };
-  if (status) (where as any).status = status;
-  if (category) (where as any).category = category;
+  if (status) (where as Record<string, unknown>).status = status;
+  if (category) (where as Record<string, unknown>).category = category;
 
   const include = [{ model: User, as: 'author', attributes: ['id', 'name'] }];
 
-  // Build order similar to listPrayers; default to updatedAt desc for "mine"
   let order: Order = [['updatedAt', dir]];
   if (sort === 'name') order = [[{ model: User, as: 'author' }, 'name', dir]];
   if (sort === 'prayer') order = [['title', dir]];
@@ -165,10 +167,11 @@ export async function listMyPrayers(req: Request, res: Response): Promise<void> 
 
     const items = rows.map((p) => toPrayerDTO(p));
     const filtered = q
-      ? items.filter((p) =>
-        p.title.toLowerCase().includes(q.toLowerCase()) ||
-        p.content.toLowerCase().includes(q.toLowerCase()) ||
-        (p.author?.name?.toLowerCase().includes(q.toLowerCase()) ?? false)
+      ? items.filter(
+        (p) =>
+          p.title.toLowerCase().includes(q.toLowerCase()) ||
+          p.content.toLowerCase().includes(q.toLowerCase()) ||
+          (p.author?.name?.toLowerCase().includes(q.toLowerCase()) ?? false)
       )
       : items;
 
@@ -201,10 +204,10 @@ export async function createPrayer(req: Request, res: Response): Promise<void> {
 
   const created = await Prayer.create({ title, content, category, groupId, authorUserId, status: 'active' });
 
-  // ⬇️ emit full DTO (typed event)
+  // emit full DTO (typed + legacy)
   emitToGroup(groupId, Events.PrayerCreated, { prayer: toPrayerDTO(created) });
 
-  // NEW: put brand-new prayers at the top immediately, then normalize
+  // Put new prayers at the top immediately, then normalize
   try {
     const minPosRaw = await Prayer.min('position', { where: { groupId, status: 'active' } });
     let nextPos = -1;
@@ -213,7 +216,6 @@ export async function createPrayer(req: Request, res: Response): Promise<void> {
     }
     await Prayer.update({ position: nextPos }, { where: { id: created.id } });
 
-    // Re-emit with updated position so clients reconcile
     try {
       const reloaded = await Prayer.findByPk(created.id, {
         include: [{ model: User, as: 'author', attributes: ['id', 'name'] }],
@@ -223,26 +225,26 @@ export async function createPrayer(req: Request, res: Response): Promise<void> {
         emitToGroup(groupId, 'prayer:updated', payload);
         emitToGroup(groupId, Events.PrayerUpdated, payload);
       }
-    } catch {}
+    } catch {
+      // best-effort
+    }
 
-    // Keep column dense to preserve manual sort semantics
     await normalizePositions(groupId, 'active');
   } catch {
-    // non-fatal; creation still succeeds even if bump/normalize fails
+    // non-fatal
   }
 
-  // Notify group & admin (non-fatal)
+  // Non-fatal email notifications
   const linkUrl = `${env.PUBLIC_URL}/portal/prayers/${created.id}`;
   try {
     await notifyGroupOnCategoryCreate({
       category: created.category,
       title: created.title,
       description: created.content,
-      createdByName: undefined, // keep neutral; can be wired to author name later
+      createdByName: undefined,
       linkUrl,
     });
-  } catch { /* ignore non-fatal email errors */ }
-
+  } catch {}
   try {
     await notifyAdminOnCategoryCreate({
       category: created.category,
@@ -251,7 +253,7 @@ export async function createPrayer(req: Request, res: Response): Promise<void> {
       createdByName: undefined,
       linkUrl,
     });
-  } catch { /* ignore non-fatal email errors */ }
+  } catch {}
 
   res.json(created);
 }
@@ -268,18 +270,16 @@ export async function updatePrayer(req: Request, res: Response): Promise<void> {
   const isAuthor = prayer.authorUserId === req.user!.userId;
   const isAdmin = req.user!.role === 'admin';
 
-  // Determine if this request is *only* a move (status/position) and not an edit to content/meta
   const isOnlyMove =
     title === undefined &&
     content === undefined &&
     category === undefined &&
     (status !== undefined || position !== undefined);
 
-  // Participants may move (archive/reorder), but not edit text/category
   let isParticipant = false;
   if (!isAuthor && !isAdmin && isOnlyMove) {
     const pp = await PrayerParticipant.findOne({
-      where: { prayerId: prayer.id, userId: req.user!.userId }
+      where: { prayerId: prayer.id, userId: req.user!.userId },
     });
     isParticipant = !!pp;
   }
@@ -289,10 +289,8 @@ export async function updatePrayer(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  // capture previous status to decide moved vs updated
   const prevStatus = prayer.status;
 
-  // Apply changes
   if (title !== undefined) prayer.title = title;
   if (content !== undefined) prayer.content = content;
   if (category !== undefined) prayer.category = category as any;
@@ -301,15 +299,13 @@ export async function updatePrayer(req: Request, res: Response): Promise<void> {
 
   await prayer.save();
 
-  // ⬇️ choose event by whether status changed
   if (prevStatus !== prayer.status) {
     emitToGroup(prayer.groupId, Events.PrayerMoved, {
       prayer: toPrayerDTO(prayer),
       from: prevStatus as 'active' | 'praise' | 'archived',
-      to: prayer.status as 'active' | 'praise' | 'archived'
+      to: prayer.status as 'active' | 'praise' | 'archived',
     });
   } else {
-    // Broadcast using legacy string AND typed enum (client back-compat)
     const payload = { prayer: toPrayerDTO(prayer) };
     emitToGroup(prayer.groupId, 'prayer:updated', payload);
     emitToGroup(prayer.groupId, Events.PrayerUpdated, payload);
@@ -330,19 +326,14 @@ export async function deletePrayer(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  // capture for post-delete housekeeping
   const groupId = prayer.groupId;
   const statusBeforeDelete = prayer.status;
 
   try {
     await sequelize.transaction(async (t) => {
-      // Best-effort child deletes (safe even if tables are empty).
-      // If you use ON DELETE CASCADE, these will just be redundant but harmless.
       await PrayerParticipant.destroy({ where: { prayerId: prayer.id }, transaction: t });
       await PrayerUpdate.destroy({ where: { prayerId: prayer.id }, transaction: t });
       await Attachment.destroy({ where: { prayerId: prayer.id }, transaction: t });
-
-      // Remove the root record
       await prayer.destroy({ transaction: t });
     });
   } catch {
@@ -350,23 +341,18 @@ export async function deletePrayer(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  // keep existing event name to avoid client breakage
   try {
     emitToGroup(groupId, 'prayer:deleted', { id });
   } catch {
     // non-fatal
   }
 
-  // Keep column dense so manual sorting remains meaningful (best-effort)
   try {
     await normalizePositions(groupId, statusBeforeDelete);
-  } catch {
-    // non-fatal
-  }
+  } catch {}
 
   res.json({ ok: true });
 }
-
 
 export async function createUpdate(req: Request, res: Response): Promise<void> {
   const prayerId = Number(req.params.id);
@@ -375,17 +361,13 @@ export async function createUpdate(req: Request, res: Response): Promise<void> {
   const prayer = await findPrayerOr404(prayerId, res);
   if (!prayer) return;
 
-  // Create the update record
   const upd = await PrayerUpdate.create({ prayerId, authorUserId: req.user!.userId, content });
 
-  // 1) Bump this prayer to the top of its current board by lowering its position.
-  //    Choose (min position in same group/status) - 1 to preserve existing relative order.
   try {
     const minPosRaw = await Prayer.min('position', {
-      where: { groupId: prayer.groupId, status: prayer.status }
+      where: { groupId: prayer.groupId, status: prayer.status },
     });
 
-    // HARD bump if there are no existing positions (null) by defaulting to -1
     let nextPos = -1;
     if (typeof minPosRaw === 'number' && Number.isFinite(minPosRaw)) {
       nextPos = minPosRaw - 1;
@@ -394,39 +376,31 @@ export async function createUpdate(req: Request, res: Response): Promise<void> {
     prayer.position = nextPos;
     await prayer.save();
 
-    // 2) Broadcast using legacy string AND typed enum (client back-compat)
     const payload = { prayer: toPrayerDTO(prayer) };
     try {
       emitToGroup(prayer.groupId, 'prayer:updated', payload);
-    } catch { /* non-fatal */ }
+    } catch {}
     try {
       emitToGroup(prayer.groupId, Events.PrayerUpdated, payload);
-    } catch { /* non-fatal */ }
+    } catch {}
 
-    // 3) Keep column dense so manual sorting remains meaningful
     await normalizePositions(prayer.groupId, prayer.status);
   } catch {
-    // If bump/normalize fails, the update itself still succeeds; UI just won’t auto-bump this time.
+    // update still succeeds even if bump/normalize fails
   }
 
-  // Keep existing lightweight signal (some clients may rely on it)
   try {
     emitToGroup(prayer.groupId, 'update:created', { id: upd.id, prayerId });
-  } catch {
-    // non-fatal
-  }
+  } catch {}
 
-  // Send a simple update notice to the group via Resend (non-fatal)
   try {
     const group = await Group.findByPk(prayer.groupId);
     await sendEmailViaResend({
       to: group?.groupEmail ?? env.GROUP_EMAIL,
       subject: 'Prayer Updated',
-      html: `<p>Prayer <b>${prayer.title}</b> was updated.</p><p>${content}</p>`
+      html: `<p>Prayer <b>${prayer.title}</b> was updated.</p><p>${content}</p>`,
     });
-  } catch {
-    // ignore non-fatal email errors
-  }
+  } catch {}
 
   res.json(upd);
 }
@@ -446,7 +420,7 @@ export async function addAttachments(req: Request, res: Response): Promise<void>
         filePath: path.join(env.UPLOAD_DIR, path.basename(f.path)),
         fileName: f.originalname,
         mimeType: f.mimetype,
-        size: f.size
+        size: f.size,
       })
     )
   );

--- a/Server/src/middleware/recaptcha.middleware.ts
+++ b/Server/src/middleware/recaptcha.middleware.ts
@@ -73,6 +73,7 @@ const ACTION_PATTERNS: Record<string, Array<{ method: string; paths: string[] }>
  * ---------------------------------------------------------------------------*/
 
 // Map “METHOD path” → Enterprise action (works with your existing routes)
+// Map “METHOD path” → Enterprise action (works with your existing routes)
 const ROUTE_ACTIONS: Record<string, string> = {
   // AUTH
   'POST /auth/login': 'login',
@@ -80,8 +81,20 @@ const ROUTE_ACTIONS: Record<string, string> = {
   'POST /auth/request-reset': 'password_reset_request',
   'POST /auth/reset-password': 'password_reset',
 
-  // ADMIN
+  // ADMIN (existing)
   'POST /admin/promote': 'admin_promote',
+
+  // ADMIN status patch (expect what your client actually uses)
+  'PATCH /api/admin/prayers/:id/status': 'admin_patch_status',
+  'PATCH /admin/prayers/:id/status': 'admin_patch_status',
+  'PATCH /api/admin/prayers/:prayerId/status': 'admin_patch_status',
+  'PATCH /admin/prayers/:prayerId/status': 'admin_patch_status',
+
+  // ADMIN delete (unchanged)
+  'DELETE /api/admin/prayers/:id': 'admin_prayer_delete',
+  'DELETE /admin/prayers/:id': 'admin_prayer_delete',
+  'DELETE /api/admin/prayers/:prayerId': 'admin_prayer_delete',
+  'DELETE /admin/prayers/:prayerId': 'admin_prayer_delete',
 
   // EXPORT
   'POST /export/prayers': 'export_prayers',
@@ -89,13 +102,14 @@ const ROUTE_ACTIONS: Record<string, string> = {
   // GROUPS
   'PATCH /groups': 'group_update',
 
-  // PRAYERS
+  // PRAYERS (public/user)
   'POST /prayers': 'prayer_create',
   'PATCH /prayers/:id': 'prayer_update',
   'DELETE /prayers/:id': 'prayer_delete',
   'POST /prayers/:id/updates': 'prayer_add_update',
   'POST /prayers/:id/attachments': 'media_upload',
 };
+
 
 // Generate multiple lookup keys that tolerate the /api prefix and router mounts
 function routeKeyCandidates(req: Request): string[] {

--- a/Server/src/routes/admin/admin.route.ts
+++ b/Server/src/routes/admin/admin.route.ts
@@ -12,6 +12,9 @@ import {
   getPrayerDetail,
 } from '../../controllers/admin/admin.controller.js';
 
+// NEW: bring in deletePrayer from your prayer.controller
+import { deletePrayer } from '../../controllers/prayer.controller.js';
+
 const router: Router = Router();
 
 // Existing
@@ -24,5 +27,8 @@ router.get('/prayers/:prayerId', requireAdmin, getPrayerDetail);
 router.get('/prayers/:prayerId/comments', requireAdmin, getPrayerThread);
 router.post('/prayers/:prayerId/comments', requireAdmin, recaptchaMiddleware, addAdminComment);
 router.patch('/prayers/:prayerId/status', requireAdmin, recaptchaMiddleware, setPrayerStatus);
+
+// NEW: hard delete prayer (admin only)
+router.delete('/prayers/:id', requireAdmin, recaptchaMiddleware, deletePrayer);
 
 export default router;


### PR DESCRIPTION
### Description

This pull request introduces multiple enhancements and refactors across the client and server for better admin prayer management:

**Server:**
- Expanded `insertAdminComment` functionality to include side-effect integrations and improved response structure.
- Enhanced admin middleware with route key normalization and mapping for robust route handling.
- Introduced DELETE and PATCH endpoints for managing prayer statuses and deletions.
- Improved prayer deletion with transaction-based handling and post-delete housekeeping.
- Cleaned up `prayer.controller` for better maintainability and readability.

**Client:**
- Updated hover styling and added transitions for improved visual feedback.
- Refactored various components (`AdminPrayerDetailPage`, `AdminPrayerSummaryCard`) for consistency and code reuse.
- Introduced delete confirmation UI and logic in `AdminPrayerDetailPage`.
- Added `deletePrayer` method to `useAdminStore` and integrated `deleteAdminPrayer` API for backend interaction.
- Improved status display in `AdminPrayerSummaryCard` for better readability. 

These changes enhance user experience and functionality, improve code quality, and streamline prayer management across the admin interface.