### PR TITLE
Add email service and functionality for event notifications

### DIFF
--- a/Client/src/helpers/api/eventsApi.ts
+++ b/Client/src/helpers/api/eventsApi.ts
@@ -100,3 +100,19 @@ export async function deleteEvent(id: number): Promise<boolean> {
     return false;
   }
 }
+
+// Email an event to roster (admins only; uses reCAPTCHA)
+export async function emailEvent(id: number): Promise<boolean> {
+  try {
+    const res = await apiWithRecaptcha(`/api/admin/events/${id}/email`, 'admin_event_email', {
+      method: 'POST',
+      credentials: 'include',
+    });
+
+    const { ok, body } = await readBody(res);
+    if (!ok) return false;
+    return body?.ok === true;
+  } catch {
+    return false;
+  }
+}

--- a/Client/src/pages/EventsPage.tsx
+++ b/Client/src/pages/EventsPage.tsx
@@ -1,14 +1,14 @@
 // Client/src/pages/EventsPage.tsx
 import React, { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
-import { ChevronDown } from 'lucide-react'; // if you use react-lucide, change to: import { ChevronDown } from 'react-lucide';
+import { ChevronDown } from 'lucide-react';
 import { useAuthStore } from '../stores/useAuthStore';
 import {
   fetchEvents,
   createEvent,
   updateEvent,
   deleteEvent,
-  type EventRow,
+  type EventRow, emailEvent,
 } from '../helpers/api/eventsApi';
 import EventModal from '../modals/EventModal'; // ✅
 
@@ -384,18 +384,41 @@ export default function EventsPage(): React.ReactElement {
 
                   {/* Admin actions live OUTSIDE the content button (no nesting) */}
                   {isAdmin && (
-                    <div className="mt-3 flex shrink-0 gap-2">
+                    <div className="mt-3 flex items-center gap-2">
                       <button
                         type="button"
                         onClick={() => beginEdit(ev.id)}
-                        className="rounded-lg border border-[var(--theme-border)] px-3 py-1 text-sm bg-[var(--theme-button)] text-[var(--theme-text-white)] hover:bg-[var(--theme-button-hover)] hover:text-[var(--theme-textbox)]"
+                        className="rounded-lg border border-[var(--theme-border)] px-3 py-1 text-sm bg-[var(--theme-button-dark)] text-[var(--theme-accent)] hover:bg-[var(--theme-button-hover)] hover:text-[var(--theme-textbox)]"
                       >
                         Edit
                       </button>
+
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          // Email this event to roster
+                          try {
+                            const ok = await emailEvent(ev.id);
+                            if (ok) {
+                              toast.success('Event emailed to the group.');
+                            } else {
+                              toast.error('Could not send the email.');
+                            }
+                          } catch {
+                            toast.error('Could not send the email.');
+                          }
+                        }}
+                        className="rounded-lg border border-[var(--theme-border)] px-3 py-1 text-sm bg-[var(--theme-button-dark)] text-[var(--theme-accent)] hover:bg-[var(--theme-button-hover)] hover:text-[var(--theme-textbox)]"
+                        aria-label="Email this event to the group"
+                        title="Email this event to the group"
+                      >
+                        Email Group
+                      </button>
+
                       <button
                         type="button"
                         onClick={() => removeRow(ev.id)}
-                        className="rounded-lg bg-[var(--theme-error)] px-3 py-1 text-sm text-white hover:opacity-90"
+                        className="rounded-lg bg-[var(--theme-error)] hover:bg-[var(--theme-button-error)] px-3 py-1 text-sm text-white hover:opacity-90"
                       >
                         Delete
                       </button>

--- a/Server/src/email/resend.templates.ts
+++ b/Server/src/email/resend.templates.ts
@@ -322,3 +322,57 @@ function escapeHtml(s: string): string {
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
 }
+
+// --- Event single-card email (compact, same palette & table layout) ---
+export function renderEventEmailHtml(opts: {
+  groupName: string;
+  title: string;
+  content?: string;
+  startsAt?: string | Date | null;
+  endsAt?: string | Date | null;
+  location?: string | null;
+  actionUrl?: string;
+}): string {
+  const { groupName, title, content, startsAt, endsAt, location, actionUrl } = opts;
+
+  function toDateLocal(input: unknown): string | null {
+    try {
+      if (!input) return null;
+      const d = new Date(input as any);
+      if (Number.isNaN(d.getTime())) return null;
+      return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+    } catch {
+      return null;
+    }
+  }
+
+  const whenStart = toDateLocal(startsAt);
+  const whenEnd = toDateLocal(endsAt);
+  const when = whenStart && whenEnd ? `${whenStart} – ${whenEnd}` : whenStart || null;
+
+  const detailsRows = [
+    when ? `<div style="margin:0 0 6px 0;"><strong>When:</strong> ${escapeHtml(when)}</div>` : '',
+    location ? `<div style="margin:0 0 6px 0;"><strong>Where:</strong> ${escapeHtml(location)}</div>` : '',
+  ].join('');
+
+  const body = content ? `<div style="white-space:pre-wrap;line-height:1.6;margin-top:8px;">${escapeHtml(content)}</div>` : '';
+
+  const cta = actionUrl
+    ? `<a href="${escapeHtml(actionUrl)}" style="display:inline-block;margin-top:16px;padding:10px 14px;background:${COL.BTN_BG};color:${COL.BTN_TEXT};text-decoration:none;border-radius:8px;">Open Events</a>`
+    : '';
+
+  return `
+  <div style="background:${COL.BG};padding:24px;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="max-width:640px;margin:0 auto;background:${COL.SURFACE};border:1px solid ${COL.BORDER};border-radius:12px;">
+      <tr>
+        <td style="padding:20px 22px;">
+          <div style="font-size:14px;color:${COL.D};margin-bottom:6px;">${escapeHtml(groupName)}</div>
+          <h1 style="margin:0 0 8px 0;font-size:20px;line-height:1.3;color:${COL.TEXT};">${escapeHtml(title)}</h1>
+          ${detailsRows}
+          ${body}
+          ${cta}
+        </td>
+      </tr>
+    </table>
+  </div>`;
+}

--- a/Server/src/middleware/recaptcha.middleware.ts
+++ b/Server/src/middleware/recaptcha.middleware.ts
@@ -96,6 +96,7 @@ const ACTION_PATTERNS: Record<string, Array<{ method: string; paths: string[] }>
   admin_event_create: [{ method: 'POST',   paths: ['/api/admin/events', '/admin/events'] }],
   admin_event_update: [{ method: 'PATCH',  paths: ['/api/admin/events/:id', '/admin/events/:id'] }],
   admin_event_delete: [{ method: 'DELETE', paths: ['/api/admin/events/:id', '/admin/events/:id'] }],
+  admin_event_email: [{ method: 'POST', paths: ['/api/admin/events/:id/email', '/admin/events/:id/email', '/:id/email'] }],
 };
 
 /** ----------------------------------------------------------------------------
@@ -154,6 +155,11 @@ const NORMALIZED_ROUTE_ACTIONS: Record<string, string> = {
   // Admin delete & status (canonical)
   'DELETE /api/admin/prayers/:id': 'admin_prayer_delete',
   'PATCH /api/admin/prayers/:id/status': 'admin_patch_status',
+  // Email a single event to the group
+  'POST /api/admin/events/:id/email': 'admin_event_email',
+  'POST /admin/events/:id/email': 'admin_event_email', // legacy/non-api fallback
+  'POST /:id/email': 'admin_event_email',              // router-local safety
+
 };
 
 // Generate multiple lookup keys that tolerate the /api prefix and router mounts

--- a/Server/src/routes/admin/events.admin.route.ts
+++ b/Server/src/routes/admin/events.admin.route.ts
@@ -8,6 +8,7 @@ import {
   adminDeleteEvent,
   adminListEvents,
   adminUpdateEvent,
+  adminEmailEvent, // ✅ add
 } from '../../controllers/admin/events.admin.controller.js';
 
 const router: Router = Router();
@@ -23,5 +24,8 @@ router.patch('/:id', requireAuth, requireAdmin, recaptchaMiddleware, adminUpdate
 
 // Delete
 router.delete('/:id', requireAuth, requireAdmin, recaptchaMiddleware, adminDeleteEvent);
+
+// Email event to roster (admins only; reCAPTCHA protected)
+router.post('/:id/email', requireAuth, requireAdmin, recaptchaMiddleware, adminEmailEvent); // ✅ NEW
 
 export default router;

--- a/Server/src/services/admin/eventEmail.service.ts
+++ b/Server/src/services/admin/eventEmail.service.ts
@@ -1,0 +1,144 @@
+// Server/src/services/admin/eventEmail.service.ts
+import { Event, Group, GroupMember, User } from '../../models/index.js';
+import { sendEmail } from '../email.service.js';
+import { renderEventEmailHtml } from '../../email/resend.templates.js';
+
+type Result<T> = { ok: true; data: T } | { ok: false; error?: string };
+
+function isEmail(v: unknown): v is string {
+  return typeof v === 'string' && v.includes('@');
+}
+
+export async function loadEventById(id: number): Promise<Result<Event>> {
+  try {
+    const row = await Event.findByPk(id);
+    if (!row) return { ok: false, error: 'Event not found.' };
+    return { ok: true, data: row };
+  } catch {
+    return { ok: false, error: 'Event lookup failed.' };
+  }
+}
+
+export async function computeRecipients(groupId: number): Promise<{ to: string[]; cc: string[]; groupAddress?: string }> {
+  let groupAddress: string | undefined;
+  try {
+    const grp = await Group.findByPk(groupId);
+    if (grp?.groupEmail && isEmail(grp.groupEmail)) {
+      groupAddress = grp.groupEmail;
+    }
+  } catch {
+    // ignore; groupAddress stays undefined
+  }
+
+  // TO: all active member emails (emailPaused = false)
+  let to: string[] = [];
+  try {
+    const members = await GroupMember.findAll({
+      where: { groupId },
+      include: [
+        {
+          model: User,
+          as: 'user',
+          required: true,
+          where: { emailPaused: false },
+          attributes: ['email', 'emailPaused'],
+        },
+      ],
+      limit: 5000,
+    });
+
+    to = members
+      .map((m: any) => m?.user?.email)
+      .filter(isEmail);
+  } catch {
+    // fallback: all users (paused filtered in app)
+    try {
+      const users = await User.findAll({
+        where: { emailPaused: false },
+        attributes: ['email', 'emailPaused'],
+        limit: 5000,
+      });
+      to = users.filter((u: any) => !u?.emailPaused).map((u: any) => u?.email).filter(isEmail);
+    } catch {
+      // last resort: no recipients
+      to = [];
+    }
+  }
+
+  // CC: all admins (emailPaused = false), plus groupAddress (if present)
+  let cc: string[] = [];
+  try {
+    const admins = await User.findAll({
+      where: { role: 'admin', emailPaused: false } as any,
+      attributes: ['email'],
+      limit: 500,
+    });
+    cc = admins.map((u: any) => u?.email).filter(isEmail);
+  } catch {
+    cc = [];
+  }
+
+  if (groupAddress && !cc.includes(groupAddress)) {
+    cc.push(groupAddress);
+  }
+
+  // de-dup TO and CC; also make sure we don’t duplicate the group address in TO
+  const dedup = (arr: string[]) => Array.from(new Set(arr));
+  const toSet = new Set(dedup(to).filter((e) => e !== groupAddress));
+  const ccSet = new Set(dedup(cc).filter((e) => !toSet.has(e)));
+
+  return { to: Array.from(toSet), cc: Array.from(ccSet), groupAddress };
+}
+
+export async function sendEventEmail(params: { eventId: number; requestedById: number }): Promise<{ ok: boolean; error?: string }> {
+  const eventRes = await loadEventById(params.eventId);
+  if (!eventRes.ok) return { ok: false, error: eventRes.error || 'Event lookup failed.' };
+  const ev = eventRes.data;
+
+  const { to, cc, groupAddress } = await computeRecipients(ev.groupId);
+
+  if (!to.length && !cc.length) {
+    return { ok: false, error: 'No valid recipients.' };
+  }
+
+  const subjectParts: string[] = [];
+  subjectParts.push('FBS Event');
+  if (ev.title) subjectParts.push(String(ev.title));
+  const subject = subjectParts.join(' — ');
+
+  const html = renderEventEmailHtml({
+    groupName: 'Friday Bible Study',
+    title: String(ev.title ?? 'Untitled Event'),
+    content: String(ev.content ?? ''),
+    startsAt: ev.startsAt ?? null,
+    endsAt: ev.endsAt ?? null,
+    location: ev.location ?? null,
+    actionUrl: process.env.PUBLIC_APP_URL ? `${process.env.PUBLIC_APP_URL}/events` : undefined,
+  });
+
+  try {
+    let toFinal: string[] = [];
+
+    if (to.length > 0) {
+      toFinal = to;
+    } else if (cc.length > 0) {
+      // fall back to cc if no direct recipients
+      toFinal = cc;
+    } else {
+      toFinal = [];
+    }
+
+    await sendEmail({
+      // From: prefer group mailbox so replies thread into group inbox if configured
+      from: groupAddress || undefined,
+      to: toFinal,
+      cc: cc.length > 0 ? cc : undefined,
+      replyTo: groupAddress || undefined,
+      subject,
+      html,
+    });
+    return { ok: true };
+  } catch {
+    return { ok: false, error: 'Email send failed.' };
+  }
+}


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

- **Server-side features:**
  - Implemented `sendEventEmail` service for sending email notifications about specific events.
  - Created `adminEmailEvent` endpoint to send emails to event rosters with appropriate protections like reCAPTCHA, authentication, and admin checks.
  - Added `loadEventById` and `renderEventEmailHtml` utilities for retrieving event data and generating email templates in a styled, table-based layout.
  - Developed `computeRecipients` logic to determine recipient lists, including admins and group members.

- **Client-side additions:**
  - Added an "Email Group" action button in the admin view of EventsPage, enabling event notifications.
  - Introduced the `emailEvent` helper to send emails from the client securely with reCAPTCHA integration.
  - Enhanced admin UI with feedback mechanisms using `react-hot-toast`.

These updates provide a robust framework for notifying admins and roster members of specific event details effectively.